### PR TITLE
Fix to not use yargs command handler options

### DIFF
--- a/functions/src/commands/exec.ts
+++ b/functions/src/commands/exec.ts
@@ -1,0 +1,13 @@
+export const command = 'exec <bot> [args..]'
+export const desc = 'Exec a bot'
+
+export function execute({ args }) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve({
+        response_type: "in_channel",
+        text: `Exec ${args.bot} ${args.args}`,
+      })
+    }, 16)
+  })
+}

--- a/functions/src/commands/invite.ts
+++ b/functions/src/commands/invite.ts
@@ -1,8 +1,15 @@
 export const command = 'invite <bot>'
 export const desc = 'Invite a bot'
-export function handler(argv) {
-  argv._reply = {
+export const builder = {
+  bot: {
+    desc: 'bot name to invite',
+    type: 'string'
+  }
+}
+
+export async function execute({ args }) {
+  return {
     response_type: "in_channel",
-    text: `Invited ${argv.bot}`,
+    text: `Invited ${args.bot}`,
   }
 }

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -2535,8 +2535,8 @@ yargs-parser@^9.0.2:
     camelcase "^4.1.0"
 
 yargs@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:
     cliui "^4.0.0"
     decamelize "^1.1.1"


### PR DESCRIPTION
issue #8

* yargs の command ディレクティブの handler オプションを使わないようにし、コマンドの実行を独自で行うようにした
* それによって、非同期なコマンドの実行が可能になった