### PR TITLE
Implement fetching brain from Slack message

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,6 +26,8 @@ export const slackCommand = functions.https.onRequest((request, response) => {
       return
     }
 
+    console.log(request.body)
+
     const args = toArgs(messageText)
 
     yargs
@@ -58,6 +60,6 @@ export const slackCommand = functions.https.onRequest((request, response) => {
     })
     .catch((reason) => {
       console.error(reason)
-      response.status(reason.status).json(reason.res)
+      response.status(reason.status || '500').json(reason.res)
     })
 })


### PR DESCRIPTION
issue #5

# 概要

* exec コマンドで Slack message にマッチする bot の brain を取得する

# スクリーンショット
## スコープ内でかつボットがスコープ内に invite されている場合

[![https://gyazo.com/c370ffc3fa2da15a76d0aed48ea82ba2](https://i.gyazo.com/c370ffc3fa2da15a76d0aed48ea82ba2.png)](https://gyazo.com/c370ffc3fa2da15a76d0aed48ea82ba2)

## スコープ外の場合

[![https://gyazo.com/2645983e69f49497fb015c1ba1faec75](https://i.gyazo.com/2645983e69f49497fb015c1ba1faec75.png)](https://gyazo.com/2645983e69f49497fb015c1ba1faec75)

## 存在しないボットの場合

[![https://gyazo.com/5e95a2726da7dffc282b5c371c7df8de](https://i.gyazo.com/5e95a2726da7dffc282b5c371c7df8de.png)](https://gyazo.com/5e95a2726da7dffc282b5c371c7df8de)